### PR TITLE
Remove old beta modules refs

### DIFF
--- a/mkdocs-project-dir/docs/Clusters/Myriad.md
+++ b/mkdocs-project-dir/docs/Clusters/Myriad.md
@@ -182,8 +182,7 @@ module load tensorflow/2.0.0/gpu-py37
 Modules to load the most recent version we have installed with GPU support (2.11.0):
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python/3.9.6-gnu-10.2.0
 module load cuda/11.2.0/gnu-10.2.0
@@ -200,8 +199,7 @@ Modules to load the most recent release we have installed (May 2022)
 are:
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python3/3.9-gnu-10.2.0
 module load cuda/11.3.1/gnu-10.2.0
@@ -212,8 +210,7 @@ module load pytorch/1.11.0/gpu
 If you want the CPU only version then use:
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python3/3.9-gnu-10.2.0
 module load pytorch/1.11.0/cpu

--- a/mkdocs-project-dir/docs/Software_Guides/Installing_Software.md
+++ b/mkdocs-project-dir/docs/Software_Guides/Installing_Software.md
@@ -86,13 +86,12 @@ Useful resources:
 ### Newer versions of GCC and GLIBCXX
 
 The software you want to run may require newer compilers or a precompiled binary may say 
-that it needs a newer GLIBCXX to be able to run. You can access these as follows:
+that it needs a newer GLIBCXX to be able to run. `module avail compilers` will show you all
+the available compilers and you can then use them as follows:
 
 ```
-# make all the newer versions visible
-module load beta-modules
 # unload current compiler, mpi and gcc-libs modules
-module unload -f compilers mpi gcc-libs
+module unload compilers mpi gcc-libs
 # load GCC 10.2.0
 module load gcc-libs/10.2.0
 module load compilers/gnu/10.2.0
@@ -101,6 +100,8 @@ module load compilers/gnu/10.2.0
 The `gcc-libs` module contains the actual compiler and libraries, while the `compilers/gnu` 
 module sets environment variables that are likely to be picked up by build systems, telling them
 what the C, C++ and Fortran compilers are called.
+
+The `compilers/intel` modules will also depend on a certain version of `gcc-libs`.
 
 ### GLIBC version error
 

--- a/mkdocs-project-dir/docs/Software_Guides/Other_Software.md
+++ b/mkdocs-project-dir/docs/Software_Guides/Other_Software.md
@@ -30,11 +30,10 @@ module help <module>    # Shows a longer text description for the software
 
 Generically, the way you find out if a piece of software is installed is to run
 ```
-module load beta-modules
 module avail packagename
 ```
 
-By loading `beta-modules` you will also be able to see newer versions of GCC and the software that
+The output will also contain newer versions of GCC and the software that
 has been built using them.
 
 Then `module avail` gives you a list of all the modules we have that match the name you searched 
@@ -248,15 +247,13 @@ CP2K performs atomistic and molecular simulations.
 To see all available versions type
 
 ```
-module load beta-modules
 module avail cp2k
 ```
 
 To load CP2K 8.2:
 
 ```
-module unload -f compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load compilers/gnu/10.2.0
 
@@ -616,8 +613,7 @@ that version is installed in.
 
 ```
 # Example for GPU gromacs/2021.5/cuda-11.3
-module load beta-modules
-module unload -f compilers mpi gcc-libs
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load compilers/gnu/10.2.0
 module load python3/3.9-gnu-10.2.0 
@@ -631,8 +627,7 @@ module load gromacs/2021.5/cuda-11.3
 
 ```
 # Example for gromacs/2021.2/gnu-7.3.0
-module load beta-modules
-module unload -f compilers mpi gcc-libs
+module unload compilers mpi gcc-libs
 module load gcc-libs/7.3.0
 module load compilers/gnu/7.3.0
 module load mpi/openmpi/3.1.4/gnu-7.3.0
@@ -843,8 +838,7 @@ gerun $(which lmp_default) -in inputfile
 For the latest version of LAMMPS we have installed which is 29th September 2021 Update 2 where the binaries are called `lmp_mpi` for the MPI version and `lmp_gpu` for the GPU version:
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load compilers/gnu/10.2.0
 module load mpi/openmpi/4.0.5/gnu-10.2.0
@@ -855,8 +849,7 @@ gerun lmp_mpi -in inputfile
 ```
 for the basic MPI version and:
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load compilers/gnu/10.2.0
 
@@ -893,8 +886,7 @@ gerun lmp_mpi -in inputfile
 
 ```
 # LAMMPS 29 Sep 2021 Update 2 for GPU with Intel compilers
-module unload -f compilers mpi
-module load beta-modules
+module unload compilers mpi
 module load compilers/intel/2020/release
 module load mpi/intel/2019/update6/intel
 module load python/3.9.10
@@ -1144,8 +1136,7 @@ with OmniPath interconnects as well as GPUs (not Myriad). It can run across mult
 #$ -pe smp 24
 #$ -l gpu=2
 
-module unload -f compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/7.3.0
 module load compilers/intel/2019/update5
 module load mpi/intel/2019/update5/intel

--- a/mkdocs-project-dir/docs/Supplementary/GPU_Nodes.md
+++ b/mkdocs-project-dir/docs/Supplementary/GPU_Nodes.md
@@ -19,9 +19,6 @@ You can see all the available CUDA modules by typing
 module avail cuda
 ```
 
-The ones that become visible once you load `beta-modules` have been built with newer
-compilers.
-
 ## Sample CUDA code
 
 There are samples in some CUDA install locations, e.g. 

--- a/mkdocs-project-dir/docs/Supplementary/GPU_Nodes.md
+++ b/mkdocs-project-dir/docs/Supplementary/GPU_Nodes.md
@@ -16,7 +16,6 @@ There are several types of GPU nodes available in Myriad.
 You can see all the available CUDA modules by typing
 
 ```
-module load beta-modules
 module avail cuda
 ```
 
@@ -150,8 +149,7 @@ module load tensorflow/2.0.0/gpu-py37
 Modules to load the most recent version we have installed with GPU support (2.11.0):
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python/3.9.6-gnu-10.2.0
 module load cuda/11.2.0/gnu-10.2.0
@@ -169,8 +167,7 @@ Modules to load the most recent release we have installed (May 2022)
 are:
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python3/3.9-gnu-10.2.0
 module load cuda/11.3.1/gnu-10.2.0
@@ -181,8 +178,7 @@ module load pytorch/1.11.0/gpu
 If you want the CPU only version then use:
 
 ```
-module -f unload compilers mpi gcc-libs
-module load beta-modules
+module unload compilers mpi gcc-libs
 module load gcc-libs/10.2.0
 module load python3/3.9-gnu-10.2.0
 module load pytorch/1.11.0/cpu

--- a/mkdocs-project-dir/docs/Supplementary/Young_GPU_Nodes.md
+++ b/mkdocs-project-dir/docs/Supplementary/Young_GPU_Nodes.md
@@ -54,11 +54,10 @@ affecting your timings.
 
 ## CUDA versions
 
-The newer CUDA installs we have are made visible by first loading `beta-modules`
-but can then be used alongside any other compiler.
+The newer CUDA installs are visible in `module avail` with a reference to a newer
+gnu compiler in their names but can be used alongside any other compiler.
 
 ```
-module load beta-modules
 module avail cuda
 
 # pick one of the 11.x CUDA installs


### PR DESCRIPTION
Removed the places where it says you need to load beta-modules before being able to see newer software. Also the module load -f from the same places.