### PR TITLE
Adds local storage consent dialogue

### DIFF
--- a/mkdocs-project-dir/mkdocs.yml
+++ b/mkdocs-project-dir/mkdocs.yml
@@ -137,5 +137,17 @@ extra:
   social:
     - icon: 'fontawesome/brands/github'
       link: 'https://github.com/UCL-ARC'
+  consent:
+      github:
+      actions:
+        - reject
+        - manage
+        - accept
+      title: Local storage notification
+      description: >-
+        We don't use cookies at all, but we do use your browser's local
+        storage to remember whether you prefer dark or light mode, and
+        to store the GitHub statistics displayed in the top-right.\n
+        You can disable the stats retrieval to GitHub and associated storage here.
 extra_css:
       - 'stylesheets/tweaks.css'


### PR DESCRIPTION
Frankly, I'd rather disable the GitHub connection entirely, but you can't do that without disabling the repo link in the top right, and that's useful to keep.