### PR TITLE
Adding notice to Myriad how to use paid resources page that no longer available

### DIFF
--- a/mkdocs-project-dir/docs/Paid-For_Resources/How_to_Use.md
+++ b/mkdocs-project-dir/docs/Paid-For_Resources/How_to_Use.md
@@ -5,6 +5,11 @@ layout: docs
 
 # Using Paid-For Resources
 
+!!! important "16 July 2026: Myriad paid resources no longer available"
+    Paid resources should be available in a future cluster. The information below is obsolete.
+
+    Please contact rc-support@ucl.ac.uk. 
+
 Paid resources may be in the form of priority access (Gold), dedicated nodes
 or both.
 


### PR DESCRIPTION
Based on a conversation with @heatherkellyucl on Slack it seems that the notice on the 'Purchasing in Myriad' page

https://github.com/UCL-ARC/mkdocs-rc-docs/blob/918db5538a1a681412e1c0644908d01ecbea67ad/mkdocs-project-dir/docs/Paid-For_Resources/Purchasing_in_Myriad.md?plain=1#L7-L12

that paid access is no longer available also applies to the priority 'Gold' access described on the 'How to use' page.

As users may arrive directly as the 'How to use' page without seeing the notice on the 'Purchasing in Myriad' page, and the notice there specifically mentions adding new hardware which is not necessarily obvious will also affect priority access, this PR suggests adding a matching notice to the top of the 'How to use' page. I have matched the notice date to the previous notice on the assumption that this will be less confusing for users.