### PR TITLE
Adds AI accountability notes to T&C

### DIFF
--- a/mkdocs-project-dir/docs/Terms_and_Conditions.md
+++ b/mkdocs-project-dir/docs/Terms_and_Conditions.md
@@ -97,7 +97,7 @@ happens.
 
 ### Autonomous & Agentic AI Tools
 
-We have not yet determined whether to allow the use of non-deterministic automated systems that incorporate e.g. Large-Language Models into the control flow on our clusters.
+On our clusters, we have not yet decided whether to allow the use of non-deterministic automated systems that incorporate e.g. Large-Language Models into the control flow.
 
 However, in the meanwhile, the following applies:
 

--- a/mkdocs-project-dir/docs/Terms_and_Conditions.md
+++ b/mkdocs-project-dir/docs/Terms_and_Conditions.md
@@ -95,6 +95,14 @@ When filesystems or clusters are retired, they will be decommissioned and we wil
 the data left on them. Barring unforeseen circumstances, you will receive three months' notice before this
 happens.
 
+### Autonomous Systems
+
+We have not yet determined whether and how it should be permissible to use non-deterministic automated systems that incorporate e.g. Large-Language Models into the control flow, or whether and how this should be affected by whether the system involves making control-flow-influencing requests to an external system.
+
+However, in the meanwhile, the following applies:
+
+ - You are fully responsible and accountable for the results of any actions taken by an automated system you use.
+ - This includes actions that breach security boundaries, actions that disrupt or impair the operation of systems, actions that harm other users, and actions that delete or modify data.
 
 ## Acknowledgement in Works
 

--- a/mkdocs-project-dir/docs/Terms_and_Conditions.md
+++ b/mkdocs-project-dir/docs/Terms_and_Conditions.md
@@ -95,9 +95,9 @@ When filesystems or clusters are retired, they will be decommissioned and we wil
 the data left on them. Barring unforeseen circumstances, you will receive three months' notice before this
 happens.
 
-### Autonomous Systems
+### Autonomous & Agentic AI Tools
 
-We have not yet determined whether and how it should be permissible to use non-deterministic automated systems that incorporate e.g. Large-Language Models into the control flow, or whether and how this should be affected by whether the system involves making control-flow-influencing requests to an external system.
+We have not yet determined whether to allow the use of non-deterministic automated systems that incorporate e.g. Large-Language Models into the control flow on our clusters.
 
 However, in the meanwhile, the following applies:
 


### PR DESCRIPTION
Definitely needs review and careful consideration of the wording, but I think we probably need to address this here.

Strictly, it's a clarification of existing policy rather than a new clause, I think.

We probably need full-chain approval on it, as well. If nothing else, it would be ideal to get people prepared to back us up when someone complains that we threw them off the system because e.g. their Claude instance managed to find an exploit and delete everyone else's jobs.